### PR TITLE
Log output from setup.py as it happens instead of waiting for end

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.5</source>
-					<target>1.5</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
For exceptionally large projects, setup.py can hang if its output buffer
fills. This fixes that by regularly flushing the output buffer while
the process is running. Also a few style improvements. Note that this
does make this now require Java 8.

@UltimateDogg 